### PR TITLE
Remove All KSMA links

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -8,7 +8,7 @@
 
 ## Get help claiming KSM
 
-[KSM Claims Support chat](https://riot.im/app/#/room/#KSMAClaims:polkadot.builders)
+[KSM Claims Support chat](https://riot.im/app/#/room/#KSMClaims:polkadot.builders)
 
 ## Report an issue or submit bugs
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -8,7 +8,7 @@
 
 ## Get help claiming KSM
 
-[KSM Claims Support chat](https://riot.im/app/#/room/#KSMClaims:polkadot.builders)
+[KSM Claims Support chat](https://riot.im/app/#/room/#KSMAClaims:polkadot.builders)
 
 ## Report an issue or submit bugs
 

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -1,21 +1,21 @@
 # Contact
 
 ## General
-[Kusama forum](https://forum.kusama.network/)  
-[Kusama chat](https://riot.im/app/#/room/#kusamawatercooler:polkadot.builders)  
-[wut@kusama.network](mailto:wut@kusama.network)  
+[Kusama forum](https://forum.kusama.network/)
+[Kusama chat](https://riot.im/app/#/room/#kusamawatercooler:polkadot.builders)
+[wut@kusama.network](mailto:wut@kusama.network)
 
 ## Get help claiming KSM
-[KSM Claims Support chat](https://riot.im/app/#/room/#KSMAClaims:polkadot.builders)  
+[KSM Claims Support chat](https://riot.im/app/#/room/#KSMClaims:polkadot.builders)
 
 ## Validator chat
-[Validator chat (English)](https://riot.im/app/#/room/%23KusamaValidatorLounge:web3.foundation)  
+[Validator chat (English)](https://riot.im/app/#/room/%23KusamaValidatorLounge:web3.foundation)
 To join the Chinese Validator chat, message [Anson](https://raw.githubusercontent.com/kusamanetwork/userguide/master/chinese-language-validators-wechat.png?token=ABIBK6VM3MAOKWE43GM3JHC5G3ARG)
 
 ## Report an issue or submit bugs
-[sos@kusama.network](mailto:sos@kusama.network)  
+[sos@kusama.network](mailto:sos@kusama.network)
 
 ## Get updates
-[@kusamanetwork](https://twitter.com/kusamanetwork)  
-[Kusama newsletter](https://kusama.network/newsletter)  
-[r/kusama](https://reddit.com/r/kusama)  
+[@kusamanetwork](https://twitter.com/kusamanetwork)
+[Kusama newsletter](https://kusama.network/newsletter)
+[r/kusama](https://reddit.com/r/kusama)

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -6,7 +6,7 @@
 [wut@kusama.network](mailto:wut@kusama.network)
 
 ## Get help claiming KSM
-[KSM Claims Support chat](https://riot.im/app/#/room/#KSMClaims:polkadot.builders)
+[KSM Claims Support chat](https://riot.im/app/#/room/#KSMAClaims:polkadot.builders)
 
 ## Validator chat
 [Validator chat (English)](https://riot.im/app/#/room/%23KusamaValidatorLounge:web3.foundation)

--- a/docs/start/claims.md
+++ b/docs/start/claims.md
@@ -85,13 +85,13 @@ Another option you may consider using are `subkey` commandline utility which wil
 There are two methods to claim KSM.
 
 **1. Dot Holders:**
-Those who participated in the Polkadot sales can claim a proportional amount of KSM prior to the launch of the network. 
+Those who participated in the Polkadot sales can claim a proportional amount of KSM prior to the launch of the network.
 
 You can do this through [this claims process](https://claim.kusama.network/).
 
 You can refer to [this detailed guide](./dot-holders.md) for a step by step walk through for how to do so.
 
-Having trouble? Get support in the KSM [Claims chat](https://riot.im/app/#/room/#KSMAClaims:polkadot.builders).
+Having trouble? Get support in the KSM [Claims chat](https://riot.im/app/#/room/#KSMClaims:polkadot.builders).
 
 **2. Faucet:**
 For those who didn’t participate in the Polkadot sale, KSM are publicly available after genesis through a faucet. Find out more [here](./faucet.md).

--- a/docs/start/claims.md
+++ b/docs/start/claims.md
@@ -91,7 +91,7 @@ You can do this through [this claims process](https://claim.kusama.network/).
 
 You can refer to [this detailed guide](./dot-holders.md) for a step by step walk through for how to do so.
 
-Having trouble? Get support in the KSM [Claims chat](https://riot.im/app/#/room/#KSMClaims:polkadot.builders).
+Having trouble? Get support in the KSM [Claims chat](https://riot.im/app/#/room/#KSMAClaims:polkadot.builders).
 
 **2. Faucet:**
 For those who didn’t participate in the Polkadot sale, KSM are publicly available after genesis through a faucet. Find out more [here](./faucet.md).

--- a/docs/try/staking.md
+++ b/docs/try/staking.md
@@ -1,32 +1,32 @@
 # Grow your stake
 
-Kusama uses NPoS (Nominated Proof-of-Stake), comprising the roles of validators and nominators to maximize chain security. Validators take the role of both validating blocks and guaranteeing the finality of the chain, while nominators can help choose the set of validators by indicating their support weighted by KSMA. 
+Kusama uses NPoS (Nominated Proof-of-Stake), comprising the roles of validators and nominators to maximize chain security. Validators take the role of both validating blocks and guaranteeing the finality of the chain, while nominators can help choose the set of validators by indicating their support weighted by KSM.
 
 Both validators and nominators will earn rewards— and may be penalized—proportional to the amount that they stake, with validators having the ability to set some payment preferences.
 
 ## Stake and validate
-Requirements: an account, KSMA, and a well-connected, fast computer
+Requirements: an account, KSM, and a well-connected, fast computer
 
 Create a “stash” account; this account should ideally be set up offline for maximum security.
 
 ## Staking and nominating FAQs
 ### What is staking?
-Staking allows KSMA holders to participate in the security and availability of Kusama by leveraging their tokens to validate. Validators who stake KSMA, have an operational validator node, and behave honestly will get rewarded with KSMA. Actors who misbehave or who are unavailable/offline will have a portion of their stake slashed as a penalty.
+Staking allows KSM holders to participate in the security and availability of Kusama by leveraging their tokens to validate. Validators who stake KSM, have an operational validator node, and behave honestly will get rewarded with KSM. Actors who misbehave or who are unavailable/offline will have a portion of their stake slashed as a penalty.
 
 ### What are the annual returns for staking?
-The exact number will vary depending on the amount of KSMA staked. If there is about 50% of KSMA staked, then each validator slot will receive about 20% annual returns for good behavior.
+The exact number will vary depending on the amount of KSM staked. If there is about 50% of KSM staked, then each validator slot will receive about 20% annual returns for good behavior.
 
 ### What do I need to stake?
-To become a validator, you need a computer with recently up-to-date specifications, a stable and fast internet connection, and KSMA to stake. If you do not have KSMA to stake, it is also possible to convince nominators to nominate you. Once you have acquired enough stake to make it into the validator set, you will start validating.
+To become a validator, you need a computer with recently up-to-date specifications, a stable and fast internet connection, and KSM to stake. If you do not have KSM to stake, it is also possible to convince nominators to nominate you. Once you have acquired enough stake to make it into the validator set, you will start validating.
 
 ### What is nominating?
-A nominator publishes a list of validator candidates that they trust, and puts down an amount of KSMA at stake to support them with. If some of these candidates are elected as validators, they share with them the payments, or the sanctions, on a per-staked-KSMA basis. Unlike validators, an unlimited number of parties can participate as nominators. As long as a nominator is diligent in their choice and only supports validator candidates with good security practices, their role carries low risk and provides a continuous source of revenue.
+A nominator publishes a list of validator candidates that they trust, and puts down an amount of KSM at stake to support them with. If some of these candidates are elected as validators, they share with them the payments, or the sanctions, on a per-staked-KSM basis. Unlike validators, an unlimited number of parties can participate as nominators. As long as a nominator is diligent in their choice and only supports validator candidates with good security practices, their role carries low risk and provides a continuous source of revenue.
 
 ### What is the maximum annual interest possible when nominating?
-The returns for nominating will vary due to several factors including, how many KSMA are staked for a given validator, how much your proportion is in that stake, and how many validators are in the set at a given time. NPoS uses @TODO
+The returns for nominating will vary due to several factors including, how many KSM are staked for a given validator, how much your proportion is in that stake, and how many validators are in the set at a given time. NPoS uses @TODO
 
 ### What do I need to nominate?
-All you need are some KSMA and decide which validator to nominate.
+All you need are some KSM and decide which validator to nominate.
 
 Learn more [here](https://medium.com/web3foundation/how-nominated-proof-of-stake-will-work-in-polkadot-377d70c6bd43).
 Discuss on the [forum](https://forum.kusama.network/) or in the [chat](https://riot.im/app/#/room/#kusamawatercooler:polkadot.builders).

--- a/docs/try/validate.md
+++ b/docs/try/validate.md
@@ -99,7 +99,7 @@ The `stash` and `controller` accounts should have at least 150 milliKSM to cover
 
 The `session` account doesn't need any KSM in order to function.
 
-You can take a look at the [claiming KSM user guide](https://kusamanetwork.github.io/KSMA-dapp/) if you  participated in the DOT token sale in 2017.  You may also use the [Kusama Faucet](https://faucet.kusama.network) to obtain more KSM later.
+You can take a look at the [claiming KSM user guide](https://kusamanetwork.github.io/KSM-dapp/) if you  participated in the DOT token sale in 2017.  You may also use the [Kusama Faucet](https://faucet.kusama.network) to obtain more KSM later.
 
 ## Bond KSM
 

--- a/docs/try/validate.md
+++ b/docs/try/validate.md
@@ -40,7 +40,7 @@ You will need to build your `kusama` from the `polkadot` source code.
 
 
 ```bash
-git clone git@github.com:paritytech/polkadot.git
+git clone https://github.com/paritytech/polkadot.git
 # To update your node, run from this step.
 cd polkadot
 cargo clean
@@ -49,6 +49,8 @@ git pull origin v0.5
 ./scripts/init.sh
 cargo install --path ./ --force
 ```
+
+Note: If you prefer to use SSH rather than HTTPS, you can replace the first line of the above with `git clone git@github.com:paritytech/polkadot.git`.
 
 This step will take a while (generally 15 - 30 minutes, depending on your hardware).
 
@@ -67,9 +69,9 @@ After installing all related dependencies, you can start your Kusama node. Start
 polkadot --chain kusama
 ```
 
-Depending on the size of the chain when you do this, this step may take anywhere from a few minutes to a few hours.  
+Depending on the size of the chain when you do this, this step may take anywhere from a few minutes to a few hours.
 
-If you are interested in determining how much longer you have to go, your server logs (printed to STDOUT from the `polkadot` process) will tell you the latest block your node has processed and verified.  You can then compare that to the current highest block via [Telemetry](https://telemetry.polkadot.io/#/Alexander) or [PolkadotJS Block Explorer](https://polkadot.js.org/apps/#/explorer) 
+If you are interested in determining how much longer you have to go, your server logs (printed to STDOUT from the `polkadot` process) will tell you the latest block your node has processed and verified.  You can then compare that to the current highest block via [Telemetry](https://telemetry.polkadot.io/#/Alexander) or [PolkadotJS Block Explorer](https://polkadot.js.org/apps/#/explorer)
 
 ## Create accounts
 
@@ -91,7 +93,7 @@ Once all accounts have been created, the overview should show you something like
 
 ## Get token
 
-To continue the following steps, you are required to get some KSM tokens for the `stash` and `controller` accounts in order to submit transactions and use these KSM as stake.  
+To continue the following steps, you are required to get some KSM tokens for the `stash` and `controller` accounts in order to submit transactions and use these KSM as stake.
 
 The `stash` and `controller` accounts should have at least 150 milliKSM to cover the existential deposit and transaction fees.  You can use the "send" functionality from the Accounts tab ( https://polkadot.js.org/apps/#/accounts ) of the Explorer to move the appropriate number of KSM to each account.  It is recommended to keep the majority of your KSM in the `stash` account, and only a small amount of KSM in the `controller` account for necessary actions.
 
@@ -124,7 +126,7 @@ After a few seconds, you should see an "ExtrinsicSuccess" message.  You should n
 
 ![dashboard validate](../img/guides/how-to-validate/polkadot-dashboard-set-session-key.jpg)
 
-Click on `Set Session Key`.  
+Click on `Set Session Key`.
 Select the `session` account created previously and click on `Set Session Key`.
 
 ## Validate
@@ -142,9 +144,9 @@ polkadot --chain kusama --validator --key="SESSION_ACCOUNT_SEED_MNEMONIC" --name
 
 Be sure to put the mnemonic phrase in double quotes ( `"`), otherwise the shell will not be able to parse it.
 
-You can give your validator any name that you like, but note that others will be able to see it, and it will be included in the list of all servers using the same telemetry server.  Since numerous people are using telemetry, it is recommended that you choose something likely to be unique. 
+You can give your validator any name that you like, but note that others will be able to see it, and it will be included in the list of all servers using the same telemetry server.  Since numerous people are using telemetry, it is recommended that you choose something likely to be unique.
 
-Make sure that the address generated from the seed corresponds to your `session` account's address. 
+Make sure that the address generated from the seed corresponds to your `session` account's address.
 
 ![terminal session key verification](../img/guides/how-to-validate/polkadot-node-seed.jpg)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ site_url: https://guide.kusama.network
 nav:
  - Home: index.md
  - Get Started:
-    - Claim KSMAs: start/claims.md
+    - Claim KSM: start/claims.md
     - Dot Holders: start/dot-holders.md
     - Faucet: start/faucet.md
  - What to Try:


### PR DESCRIPTION
NOTE: This PR replaces PR #28 

Please ensure that Hutch has added the KSM riot channel before merging. 

This PR removes any last traces of KSMA and changes them to KSM.  There are now no references to KSMA in the user guide.

```
(811) ~/web3/userguide $ grep -R -i "KSMA" *
(812) ~/web3/userguide $ 
```

This also changes the method of cloning down the repo from SSH to HTTPS.  If ssh is not set up properly to trust the github RSA fingerprint, you get a scary error message; with https, it just asks you to log in with your Github credentials.  This also seems to be a more common way for people to clone down repos.

