### PR TITLE
Re-write claiming guide for Kusama addresses

### DIFF
--- a/docs/start/claims.md
+++ b/docs/start/claims.md
@@ -12,7 +12,7 @@ For most users, we recommend using the [Polkadot UI](https://polkadot.js.org/app
 
 > NOTICE: Unfortunately at this time Kusama does not have hardware wallet support using the Ledger or Trezor products. Hopefully soon this will change!
 
-Another option you may consider using are `subkey` commandline utility which will allow you to be extra secure and generate your key on an air-gapped device. Two other options include using Enzyme in-browser wallet (like MetaMask) or the Polkawallet mobile wallet. But these require an extra step.
+Another option you may consider using is the `subkey` commandline utility which will allow you to be extra secure and generate your key on an air-gapped device. Additional two other options include the Enzyme browser extension wallet or the Polkawallet mobile wallet. But these require an extra step to make into Kusama addresses.
 
 ### Using Polkadot UI
 
@@ -64,7 +64,7 @@ Secret phrase `robust mass coconut rocket mean runway wall check tennis update m
   Address (SS58): 5HhALDcW6EabKJoXMPV6RdhDzSXiMiUrh1qnjQbVufqAHg3z
 ```
 
-The `Address (SS58)` field is what you should use to claim your KSM tokens. Never share your `Secret phrase` or `Secret seed`, as these can both control your funds.
+The `Public key (hex)` field is what you should use to claim your KSM tokens. Never share your `Secret phrase` or `Secret seed`, as these can both control your funds. (NOTE: Your Kusama address will be different than the one display by `subkey`. To see your Kusama address see the section [Getting Kusama address from Substrate or Polkadot address](#kusama-from-substrate-address)).
 
 See the [`subkey` documentation](https://substrate.dev/docs/en/ecosystem/subkey) for more usage examples.
 

--- a/docs/start/claims.md
+++ b/docs/start/claims.md
@@ -90,6 +90,8 @@ See the [`subkey` documentation](https://substrate.dev/docs/en/ecosystem/subkey)
 
 <img src="../../img/enzyme-copy-your-address.png" width=50% />
 
+7. [Get the Kusama address from the Substrate address](#kusama-from-substrate-address)
+
 ### Using Polkawallet
 
 1. Install [Polkawallet](https://polkawallet.io). Click Download and select the link corresponding to the platform you are using. On android you may need to allow installing apps from external sources. On iOS, you may need to "trust" Polkawallet in the General>Profiles & Device Management > Enterprise App Section before running the app.
@@ -107,6 +109,21 @@ See the [`subkey` documentation](https://substrate.dev/docs/en/ecosystem/subkey)
 <img src="../../img/polkawallet-accounts-page.jpg" width=50% />
 <img src="../../img/polkawallet-copy-address.jpg" width=50% />
 
+6. [Get the Kusama address from the Substrate address](#kusama-from-substrate-address)
+
+### Kusama from Substrate address
+
+If you used one of the generation methods that gave you a generic Substrate address (begins with a `5`), then you will need to take an extra step to turn this into the properly encoding Kusama address.
+
+1. Copy your Substrate generic address to clipboard
+2. Go to the [Polkadot UI](https://polkadot.js.org/apps)
+3. Go to the `Settings` tab and find the configuration for `address network prefix`
+4. Select `Substrate (development)` and click `Save and reload`
+5. Go to the `Address book` and click the `Add contact` button
+6. Enter your address and give it a name like "My Address"
+7. Go back to the `Settings` tab and select the `Kusama (canary)` option in `address network prefix` and click `Save and reload`
+8. Go back to the `Address book` and find the account you just added (it will have the same name)
+9. The address is now formatted to be a Kusama address
 
 ## Step 2. Get KSM tokens
 

--- a/docs/start/claims.md
+++ b/docs/start/claims.md
@@ -1,16 +1,18 @@
 # How to get KSM
 
-The Kusama network is Polkadot's R&D network. This guide will walk you through how to proceed with claiming KSM (Kusama tokens).
+The Kusama network is Polkadot's experimental community-focused R&D network. If you hold the DOT indicator token you are entitled to claim an equivalent amount of KSM on the Kusama network. This is so that the Kusama network is aligned with the existing DOT holders and community.
 
-In order to align Kusama with the existing DOT holders and community, if you are a DOT allocation holder you can claim the equivalent amount of Kusama tokens (ticker: KSM). There are two ways to claim either before genesis by sending a transaction on Ethereum or after genesis by signing a message using your allocation key and making a transaction on Kusama.
+The two ways to claim the KSM depends on whether you are claiming before or after the Kusama genesis. Since Kusama has not launched at the time of writing this guide, it will only cover the first case: claiming by sending a transaction on Ethereum with the key holding  DOT indicator tokens. After Kusama genesis, it will be updated to cover the second case: claiming by signing a message with the key holding DOT indicator tokens.
 
 ## Step 1. Create a Kusama account
 
-You will need a Kusama account to claim the KSM. There are a few ways you can create one. For most users, we recommend using the [Polkadot UI](https://polkadot.js.org/apps/#/explorer) since it will allow you to store your encrypted keyfile locally.
+You will need to generate a Kusama account to claim KSM. There are a few ways you can create one. 
 
-> NOTICE: Unfortunately at this time Kusama and Substrate chains do not have hardware wallet support using the Ledger or Trezor products. Hopefully soon this will change!
+For most users, we recommend using the [Polkadot UI](https://polkadot.js.org/apps/#/explorer) since it will allow you to store your encrypted keystore locally.
 
-Another option you may consider using are `subkey` commandline utility which will allow you to be extra secure and generate your key on an air-gapped device. A couple other options include using Enzyme in-browser wallet (like MetaMask) or the Polkawallet mobile wallet.
+> NOTICE: Unfortunately at this time Kusama does not have hardware wallet support using the Ledger or Trezor products. Hopefully soon this will change!
+
+Another option you may consider using are `subkey` commandline utility which will allow you to be extra secure and generate your key on an air-gapped device. Two other options include using Enzyme in-browser wallet (like MetaMask) or the Polkawallet mobile wallet. But these require an extra step.
 
 ### Using Polkadot UI
 

--- a/docs/start/claims.md
+++ b/docs/start/claims.md
@@ -16,6 +16,8 @@ Another option you may consider using is the `subkey` commandline utility which 
 
 ### Using Polkadot UI
 
+1. Open up the [Polkadot UI](https://polkadot.js.org/apps) and navigate to the `Settings` tab. Find the configuration dropdown for `address network prefix` and select `Kusama (canary)`. Click `Save and reload`.
+
 1. Navigate to the [Polkadot UI Account's Tab](https://polkadot.js.org/apps/#/accounts) and click on the `Add account` button.
 
 <img src="../../img/polkadotui-find-the-accounts-page.png" width=50% />

--- a/docs/start/dot-holders.md
+++ b/docs/start/dot-holders.md
@@ -1,6 +1,6 @@
-# Dot Holders KSM Claims
+# KSM Claims
 
-If you participated in the Polkadot sales, and have received your DOT indicator tokens, you can claim the corresponding amount of KSM. 
+If you participated in the DOT sale and have received your DOT indicator tokens, you can claim the corresponding amount of KSM. 
 
 Make sure to use your original Ethereum key during this process.
 
@@ -10,24 +10,29 @@ Make sure to use your original Ethereum key during this process.
 
 Claiming before the Kusama genesis block means that you will start the network with the balance already in your account. It is really easy to do this using the KSM claims DApp.
 
-### Claim your KSM with MyCrypto
+### Generate a Kusama address
 
-MyCrypto is the option you will use if you have stored the keys to your DOT allocation on a hardware device like a Ledger Nano S or a Trezor.
+If you haven't already done so, you will need to generate a Kusama address. See [this page](./claims.md) first!
 
-> NOTICE: It is much more secure to download and use the MyCrypto app locally, You can always find the most up-to-date releases of the desktop app on their [releases page](https://github.com/MyCryptoHQ/MyCrypto/releases).
+### Claiming your KSM with MyCrypto
 
-Once you've downloaded the MyCrypto app and run it locally (run it on an airgapped computer for maximum security), head over to the [claiming DApp](https://claim.kusama.network) and enter your Kusama address and select if you are claiming for an amendment (if this sounds strange to you, it means you should NOT click the checkbox). The DApp will generate some transaction data.
+The DApp helps you send a transaction from MyCrypto. MyCrypto is good to use in case you have stored the keys to your DOT allocation on a hardware device like a Ledger Nano S or a Trezor, and it also supports private keys, mnemonics and parity signer.
 
-Head back to the MyCrypto application and click on the Contract tab. Choose the Custom selection for the contract and copy the ABI and address of the Claims contract. The mainnet Claims contract address is `0x9a1B58399EdEBd0606420045fEa0347c24fB86c2`. Click `Access`.
+**NOTICE**: It is much more secure to download and use the MyCrypto app locally. Please make sure to download the latest version for your operating system. You can always find the most up-to-date releases of the desktop app on their [releases page](https://github.com/MyCryptoHQ/MyCrypto/releases).
 
-Select the `claim` function and enter the address of the Ethereum account that holds the balance of DOT allocation for which you would like to claim KSM.
+Once you've downloaded the MyCrypto app and run it locally (run it on an airgapped computer for maximum security), head over to the [claiming DApp](https://claim.kusama.network) and select `Claim on Ethereum (before genesis)` from the dropdown. The DApp will display the address and ABI to the Claims contract and an input asking for you to enter your Kusama address. When you paste your Kusama address in the input it will display a hex-encoded public key. 
 
-Next enter in the information that the claims DApp outputted for you. For the curious ones, this is the hex representation of your Kusama public key which is how your chosen address is derived.
+**NOTE**: If you used `subkey` to generate your address, you should already have your public key.
+
+Go to the MyCrypto application and click on the Contract tab. Choose the Custom selection for the contract and copy the address and ABI and address of the Claims contract. The mainnet Claims contract address is `0x9a1B58399EdEBd0606420045fEa0347c24fB86c2`. Click `Access`.
+
+Select the `claim` function from the dropdown and enter the address of the Ethereum account that holds the balance of DOT allocation for which you would like to claim KSM. Usually this should be the same address that you are planning to send the transaction from, in exceptional cases it would be from a different key known as the amendment key (but don't worry about this if it sounds strange to you). 
+
+Next enter in the hex encoded public key that the claims DApp outputted for you.
 
 Unlock your wallet using your preferred method and click "Sign and Send."
 
 You can click on the link to view your transaction on Etherscan, when the transaction is mined to the network then you are finished! When the Kusama network starts you will already have the balance of KSM in your Kusama address.
-
 
 ## Claiming after Kusama genesis
 This section will become available upon Kusama network launch.


### PR DESCRIPTION
Turns out Polkadot-UI already supports Kusama addresses, its just hidden away in the Settings tab. Re-wrote a large chunk of the claiming guide to correspond to this fact.

DApp already changed to only accept Kusama addresses, so this should be merged in once approved.