### PR TITLE
Fill in staking info

### DIFF
--- a/docs/try/staking.md
+++ b/docs/try/staking.md
@@ -28,7 +28,7 @@ A nominator publishes a list of validator candidates that they trust, and puts d
 
 ### Can I nominate multiple validators?
 
-Yes.  Validators are selected via the Phragmen Method.  You can think of this is a version of "approval voting" - you can approve or zero, one, or multiple validators (although of course, if you do not nominate any validators, you are not nominating and thus will not receive any rewards).
+Yes.  Validators are selected via the Phragmen Method.  You can think of this is a version of "approval voting" - you can approve zero, one, or multiple validators (although of course, if you do not nominate any validators, you are not nominating and thus will not receive any rewards).
 
 For a more in-depth explanation of Phragmen, please see the [Polkadot Wiki Phragmen](https://wiki.polkadot.network/en/latest/polkadot/learn/phragmen/) page.
 

--- a/docs/try/staking.md
+++ b/docs/try/staking.md
@@ -21,11 +21,19 @@ The exact number will vary depending on the amount of KSM staked. If there is ab
 ### What do I need to stake?
 To become a validator, you need a computer with recently up-to-date specifications, a stable and fast internet connection, and KSM to stake. If you do not have KSM to stake, it is also possible to convince nominators to nominate you. Once you have acquired enough stake to make it into the validator set, you will start validating.
 
+To become a nominator, you only need to have some KSM to stake.
+
 ### What is nominating?
 A nominator publishes a list of validator candidates that they trust, and puts down an amount of KSM at stake to support them with. If some of these candidates are elected as validators, they share with them the payments, or the sanctions, on a per-staked-KSM basis. Unlike validators, an unlimited number of parties can participate as nominators. As long as a nominator is diligent in their choice and only supports validator candidates with good security practices, their role carries low risk and provides a continuous source of revenue.
 
+### Can I nominate multiple validators?
+
+Yes.  Validators are selected via the Phragmen Method.  You can think of this is a version of "approval voting" - you can approve or zero, one, or multiple validators (although of course, if you do not nominate any validators, you are not nominating and thus will not receive any rewards).
+
+For a more in-depth explanation of Phragmen, please see the [Polkadot Wiki Phragmen](https://wiki.polkadot.network/en/latest/polkadot/learn/phragmen/) page.
+
 ### What is the maximum annual interest and rewards possible when nominating or validating?
-Returns will vary due to several factors including, how many KSM are staked for a given validator, how much your proportion is in that stake, and how many validators are in the set at a given time.
+Returns will vary based on several factors including, how many KSM are staked for a given validator, how much your proportion is in that stake, and how many validators are in the set at a given time.
 
 Annual inflation of the DOT supply will not exceed 10%.
 

--- a/docs/try/staking.md
+++ b/docs/try/staking.md
@@ -22,8 +22,15 @@ To become a validator, you need a computer with recently up-to-date specificatio
 ### What is nominating?
 A nominator publishes a list of validator candidates that they trust, and puts down an amount of KSM at stake to support them with. If some of these candidates are elected as validators, they share with them the payments, or the sanctions, on a per-staked-KSM basis. Unlike validators, an unlimited number of parties can participate as nominators. As long as a nominator is diligent in their choice and only supports validator candidates with good security practices, their role carries low risk and provides a continuous source of revenue.
 
-### What is the maximum annual interest possible when nominating?
-The returns for nominating will vary due to several factors including, how many KSM are staked for a given validator, how much your proportion is in that stake, and how many validators are in the set at a given time. NPoS uses @TODO
+### What is the maximum annual interest and rewards possible when nominating or validating?
+Returns will vary due to several factors including, how many KSM are staked for a given validator, how much your proportion is in that stake, and how many validators are in the set at a given time.
+
+Annual inflation of the DOT supply will not exceed 10%.
+
+Rewards from validating is expected to be ~ 20% annually, assuming no slashing and remaining in the validator set the entire time.  Note that only some of the rewards come from supply inflation; other rewards come from transaction fees, tips, and the like.
+
+Maximum rewards are obtained when the percentage of all DOTs staked is at 50%.
+
 
 ### What do I need to nominate?
 All you need are some KSM and decide which validator to nominate.

--- a/docs/try/staking.md
+++ b/docs/try/staking.md
@@ -4,12 +4,14 @@ Kusama uses NPoS (Nominated Proof-of-Stake), comprising the roles of validators 
 
 Both validators and nominators will earn rewards— and may be penalized—proportional to the amount that they stake, with validators having the ability to set some payment preferences.
 
-## Stake and validate
-Requirements: an account, KSM, and a well-connected, fast computer
+## Validating
 
-Create a “stash” account; this account should ideally be set up offline for maximum security.
+Running a validator is a process which requires dedicated hardware and some technical prowess.  Nominating (basically, voting with your stake on which validators will be part of the active validator set) is much less technically demanding.
 
-## Staking and nominating FAQs
+If you are interested in validating, please be sure to read the [Secure Validator Setup Page](./secure-validator-setup.md) and the [Validator Setup Guide](./validate.md).
+
+## Staking and Nominating FAQs
+
 ### What is staking?
 Staking allows KSM holders to participate in the security and availability of Kusama by leveraging their tokens to validate. Validators who stake KSM, have an operational validator node, and behave honestly will get rewarded with KSM. Actors who misbehave or who are unavailable/offline will have a portion of their stake slashed as a penalty.
 
@@ -30,7 +32,6 @@ Annual inflation of the DOT supply will not exceed 10%.
 Rewards from validating is expected to be ~ 20% annually, assuming no slashing and remaining in the validator set the entire time.  Note that only some of the rewards come from supply inflation; other rewards come from transaction fees, tips, and the like.
 
 Maximum rewards are obtained when the percentage of all DOTs staked is at 50%.
-
 
 ### What do I need to nominate?
 All you need are some KSM and decide which validator to nominate.


### PR DESCRIPTION
I noticed a @TODO in the live site on the staking page, and filled in some more information there.  I also noted that there were a few other spots on the page that had only minimal information, some of which (e.g. the validator info) which was available in more depth elsewhere on the userguide, so added some links.