### PR TITLE
Image links were dead

### DIFF
--- a/docs/try/nominating.md
+++ b/docs/try/nominating.md
@@ -12,7 +12,7 @@ Pick "Account Actions", then click the blue "New Stake" button.
 
 You will see a modal window that looks like the below:
 
-![Bonding](/img/NPoS/nominate2.png)
+![Bonding](../../img/NPoS/nominate2.png)
 
 Select a "value bonded" that is **less** than the total amount of KSM you have, so you have some left over to pay transaction fees. Be mindful of the reaping threshold - the amount that must remain in an account lest it be burned. That amount is 0.01 in Kusama, so it's recommended to keep at least 0.1 KSM in your account to be on the safe side.
 
@@ -24,7 +24,7 @@ You are now bonded. Being bonded means your tokens are locked and could be [slas
 
 Click on "Nominate" on an account you've bonded and you will be presented with another popup asking you to select some validators.
 
-![Nominating validators](/img/NPoS/nominate.png)
+![Nominating validators](../../img/NPoS/nominate.png)
 
 Select them, confirm the transaction, and you're done - you are now nominating. You should notice your balance increasing shortly.
 

--- a/docs/try/unbond.md
+++ b/docs/try/unbond.md
@@ -10,7 +10,7 @@ On this tab click on the "Account Actions" tab at the top of the screen.
 
 Here, click "Stop Nominating" on an account you're nominating with and would like to free the funds for.
 
-![Stop Nominating Button](/img/NPoS/unbond1.png)
+![Stop Nominating Button](../../img/NPoS/unbond1.png)
 
 After you confirm this transaction, your tokens will remain _bonded_. This means they stay ready to be distributed among nominees again. To actually withdraw them, you need to unbond.
 
@@ -18,15 +18,15 @@ After you confirm this transaction, your tokens will remain _bonded_. This means
 
 To unbond the amount, click the little gear icon next to the account you want to unbond money for, and select "Unbond funds".
 
-![Unbonding](/img/NPoS/unbond2.png)
+![Unbonding](../../img/NPoS/unbond2.png)
 
 Select the amount you wish to unbond and click Unbond, then confirm the transaction.
 
-![Unbonding all](/img/NPoS/unbond3.png)
+![Unbonding all](../../img/NPoS/unbond3.png)
 
 If successful, your balance will show as "unbonding" with an indicator of how many more blocks remain until the amount is fully unlocked.
 
-![Unbonding duration](/img/NPoS/unbond4.png)
+![Unbonding duration](../../img/NPoS/unbond4.png)
 
 This duration will vary depending on the network you're on and will typically be four times as fast on Kusama as it is on Polkadot.
 


### PR DESCRIPTION
Discrepancy between polkadot wiki and kusama guides makes links to images incompatible between the two. This fixes the links to make them relative.